### PR TITLE
Add Fastly surrogate key middleware

### DIFF
--- a/config/fastly.php
+++ b/config/fastly.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Surrogate Keys
+    |--------------------------------------------------------------------------
+    |
+    | List of surrogate keys that can be used to target content for purging.
+    |
+    | https://www.fastly.com/documentation/reference/http/http-headers/Surrogate-Key/
+    |
+    */
+
+    'surrogate_keys' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Surrogate Key
+    |--------------------------------------------------------------------------
+    |
+    | The default surrogate key to use when no path matches are found.
+    |
+    */
+
+    'default_surrogate_key' => 'pages',
+
+];

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ The following middleware is added to the `web` middleware group:
 
 - `SolarInvestments\Middleware\RequireVpn`
 
+The following middleware is available for use:
+
+- `SolarInvestments\Middleware\SetFastlySurrogateKey`
+
 ## Installation
 
 ```bash
@@ -18,6 +22,50 @@ composer require solar-investments/support
 ```
 
 ## Configuration
+
+### Fastly Middleware
+
+To use the `SetFastlySurrogateKey` middleware, publish the configuration file:
+
+```bash
+php artisan vendor:publish --tag=fastly-config
+```
+
+Then, set the `surrogate_keys` in the `config/fastly.php` file, e.g.:
+
+```php
+return [
+
+    'surrogate_keys' => [
+
+        [
+            /*
+             * The key to use for requests that match the specified paths.
+             *
+             * The default key will be prepended to this value.
+             */
+            'key' => 'meals',
+
+            /*
+             * List of paths that should use the specified key.
+             *
+             * A path is a match if it starts with any of the specified paths.
+             * 
+             * Note: Paths are case-insensitive. The forward slash is optional.
+             */
+            'paths' => [
+                'breakfast',
+                'lunch',
+                'dinner',
+            ],
+        ],
+
+    ],
+
+    // ...
+
+];
+```
 
 ### VPN Middleware
 

--- a/src/Middleware/SetFastlySurrogateKey.php
+++ b/src/Middleware/SetFastlySurrogateKey.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Middleware;
+
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use function now;
+
+class SetFastlySurrogateKey
+{
+    /**
+     * @param  Closure(Request): (RedirectResponse|Response)  $next
+     * @return RedirectResponse|Response
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $this->surrogateKeys()->each(function (array $surrogate) use ($request, $response): void {
+            $ttl = now()->addMinutes(5);
+
+            $surrogateKey = Str::trim($surrogate['key']);
+
+            /** @var Collection<int, string> $surrogatePaths */
+            $surrogatePaths = Cache::remember(
+                key: $this->cacheKeyForSurrogateKeyPaths($surrogateKey),
+                ttl: $ttl,
+                callback: static fn (): Collection => collect($surrogate['paths'])
+                    ->map(static fn (string $path): string => Str::of($path)
+                        ->trim()
+                        ->ltrim('/')
+                        ->lower()
+                        ->toString()
+                    )
+                    ->filter()
+                    ->unique()
+            );
+
+            /** @var string $surrogateKeys */
+            $surrogateKeys = Cache::remember(
+                key: $this->cacheKeyForSurrogateKey($surrogateKey),
+                ttl: $ttl,
+                callback: function () use ($request, $surrogateKey, $surrogatePaths): string {
+                    $keys = collect();
+
+                    if (Str::startsWith(Str::lower($request->path()), $surrogatePaths)) {
+                        $keys->push($surrogateKey);
+                    }
+
+                    return $keys->prepend(
+                        $this->defaultSurrogateKey()
+                    )->implode(' ');
+                }
+            );
+
+            $response->header('Surrogate-Key', $surrogateKeys);
+        });
+
+        $response->setPublic();
+
+        return $response;
+    }
+
+    /**
+     * @return Collection<int, array{key: string, paths: array<int, string>}>
+     */
+    public function surrogateKeys(): Collection
+    {
+        return collect(config('fastly.surrogate_keys'));
+    }
+
+    public function defaultSurrogateKey(): string
+    {
+        return Str::trim(config('fastly.default_surrogate_key'));
+    }
+
+    public function cacheKeyForSurrogateKey(string $key): string
+    {
+        return sprintf('fastly.surrogate-keys.%s', Str::slug($key));
+    }
+
+    public function cacheKeyForSurrogateKeyPaths(string $key): string
+    {
+        return sprintf('%s.paths', $this->cacheKeyForSurrogateKey($key));
+    }
+}

--- a/src/Providers/MiddlewareServiceProvider.php
+++ b/src/Providers/MiddlewareServiceProvider.php
@@ -12,6 +12,14 @@ use SolarInvestments\Middleware;
 class MiddlewareServiceProvider extends ServiceProvider
 {
     /**
+     * @var array<int, string>
+     */
+    protected array $configs = [
+        'fastly',
+        'vpn',
+    ];
+
+    /**
      * @var array<int, class-string>
      */
     protected array $middleware = [
@@ -67,8 +75,10 @@ class MiddlewareServiceProvider extends ServiceProvider
 
     protected function registerConfig(): void
     {
-        $this->publishes([
-            __DIR__.'/../../config/vpn.php' => config_path('vpn.php'),
-        ], 'vpn-config');
+        foreach ($this->configs as $config) {
+            $this->publishes([
+                __DIR__."/../../config/$config.php" => config_path("$config.php"),
+            ], "$config-config");
+        }
     }
 }

--- a/tests/Middleware/SetFastlySurrogateKeyTest.php
+++ b/tests/Middleware/SetFastlySurrogateKeyTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Tests\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SolarInvestments\Middleware\SetFastlySurrogateKey;
+use SolarInvestments\Tests\TestCase;
+
+class SetFastlySurrogateKeyTest extends TestCase
+{
+    protected const string DEFAULT_KEY = '<DEFAULT>';
+
+    public static function surrogateKeys(): array
+    {
+        return [
+            [
+                [
+                    'key' => '<KEY1>',
+                    'paths' => [
+                        'foo',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'key' => '<KEY1>',
+                    'paths' => [
+                        'foo',
+                        'bar',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'key' => '<KEY1> <KEY2>',
+                    'paths' => [
+                        'foo',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'key' => '<KEY1> <KEY2>',
+                    'paths' => [
+                        'foo',
+                        'bar',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'key' => '<KEY1>',
+                    'paths' => [
+                        '/foo',
+                        '/bar',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function surrogateCacheKeys(): array
+    {
+        return [
+            ['<KEY>', 'key'],
+            ['<KEY1> <KEY2>', 'key1-key2'],
+        ];
+    }
+
+    #[Test, DataProvider('surrogateKeys')]
+    public function it_can_set_the_surrogate_key(array $surrogateKey): void
+    {
+        config()->set('fastly.surrogate_keys', [$surrogateKey]);
+
+        $middleware = new SetFastlySurrogateKey();
+
+        foreach ($surrogateKey['paths'] as $path) {
+            $expected = sprintf(
+                '%s %s',
+                static::DEFAULT_KEY,
+                $surrogateKey['key']
+            );
+
+            $request = Request::create($path);
+
+            $response = $middleware
+                ->handle($request, fn (Request $request): Response => new Response());
+
+            $this->assertInstanceOf(Response::class, $response);
+            $this->assertSame($expected, $response->headers->get('Surrogate-Key'));
+        }
+    }
+
+    #[Test, DataProvider('surrogateKeys')]
+    public function it_can_set_the_default_surrogate_key(array $surrogateKey): void
+    {
+        config()->set('fastly.surrogate_keys', [$surrogateKey]);
+
+        $response = (new SetFastlySurrogateKey())
+            ->handle(new Request(), fn (Request $request): Response => new Response());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(static::DEFAULT_KEY, $response->headers->get('Surrogate-Key'));
+    }
+
+    #[Test]
+    public function it_can_mark_the_response_public(): void
+    {
+        $response = (new SetFastlySurrogateKey())
+            ->handle(new Request(), fn (Request $request): Response => new Response());
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+    }
+
+    #[Test, DataProvider('surrogateKeys')]
+    public function it_can_get_the_surrogate_keys(array $surrogateKey): void
+    {
+        config()->set('fastly.surrogate_keys', [$surrogateKey]);
+
+        $middleware = new SetFastlySurrogateKey();
+
+        $this->assertTrue($middleware->surrogateKeys()->contains($surrogateKey));
+    }
+
+    #[Test]
+    public function it_can_get_the_default_surrogate_key(): void
+    {
+        $middleware = new SetFastlySurrogateKey();
+
+        $this->assertSame(static::DEFAULT_KEY, $middleware->defaultSurrogateKey());
+    }
+
+    #[Test, DataProvider('surrogateCacheKeys')]
+    public function it_can_get_the_cache_key_for_surrogate_key(string $key, string $expected): void
+    {
+        $expected = "fastly.surrogate-keys.$expected";
+
+        $middleware = new SetFastlySurrogateKey();
+
+        $this->assertSame($expected, $middleware->cacheKeyForSurrogateKey($key));
+    }
+
+    #[Test, DataProvider('surrogateCacheKeys')]
+    public function it_can_get_the_cache_key_for_surrogate_key_paths(string $key, string $expected): void
+    {
+        $expected = "fastly.surrogate-keys.$expected.paths";
+
+        $middleware = new SetFastlySurrogateKey();
+
+        $this->assertSame($expected, $middleware->cacheKeyForSurrogateKeyPaths($key));
+    }
+
+    #[Test]
+    public function it_can_get_the_cached_surrogate_keys(): void
+    {
+        config()->set('fastly.surrogate_keys', [
+            [
+                'key' => '<KEY>',
+                'paths' => [
+                    'foo',
+                ],
+            ],
+        ]);
+
+        $expected = sprintf(
+            '%s %s',
+            static::DEFAULT_KEY,
+            '<KEY>'
+        );
+
+        $middleware = new SetFastlySurrogateKey();
+
+        $request = Request::create('foo');
+
+        $middleware->handle($request, fn (Request $request): Response => new Response());
+
+        $this->assertIsString($value = Cache::get(
+            key: $middleware->cacheKeyForSurrogateKey('<KEY>')
+        ));
+
+        $this->assertSame($expected, $value);
+    }
+
+    #[Test]
+    public function it_can_get_the_cached_surrogate_key_paths(): void
+    {
+        config()->set('fastly.surrogate_keys', [
+            [
+                'key' => '<KEY>',
+                'paths' => [
+                    'foo',
+                ],
+            ],
+        ]);
+
+        $expected = collect(['foo']);
+
+        $middleware = new SetFastlySurrogateKey();
+
+        $request = Request::create('foo');
+
+        $middleware->handle($request, fn (Request $request): Response => new Response());
+
+        $this->assertInstanceOf(Collection::class, $value = Cache::get(
+            key: $middleware->cacheKeyForSurrogateKeyPaths('<KEY>')
+        ));
+
+        $this->assertSame($expected->toArray(), $value->toArray());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('fastly.default_surrogate_key', static::DEFAULT_KEY);
+    }
+}


### PR DESCRIPTION
Added `SolarInvestments\Middleware\SetFastlySurrogateKey` middleware to set the surrogate (purge) keys a request matches the configured paths.

```bash
php artisan vendor:publish --tag=fastly-config
```

The following example config will set the `Surrogate-Key` header to `pages meals` when the request path starts with `breakfast`, `lunch`, or `dinner`:

```php
return [

    /*
    |--------------------------------------------------------------------------
    | Surrogate Keys
    |--------------------------------------------------------------------------
    |
    | List of surrogate keys that can be used to target content for purging.
    |
    | https://www.fastly.com/documentation/reference/http/http-headers/Surrogate-Key/
    |
    */

    'surrogate_keys' => [
        [
            /*
             * The key to use for requests that match the specified paths.
             *
             * The default key will be prepended to this value.
             */
            'key' => 'meals',

            /*
             * List of paths that should use the specified key.
             *
             * A path is a match if it starts with any of the specified paths.
             * 
             * Note: Paths are case-insensitive. The forward slash is optional.
             */
            'paths' => [
                'breakfast',
                'lunch',
                'dinner',
            ],
        ],
    ],

    /*
    |--------------------------------------------------------------------------
    | Default Surrogate Key
    |--------------------------------------------------------------------------
    |
    | The default surrogate key to use when no path matches are found.
    |
    */

    'default_surrogate_key' => 'pages',

];
```