### PR TITLE
Allow all IP addresses by default

### DIFF
--- a/src/Middleware/RequireVpn.php
+++ b/src/Middleware/RequireVpn.php
@@ -57,7 +57,7 @@ class RequireVpn
     public function allowedIps(): array
     {
         /** @var array|array<int, string>|string $values */
-        $values = config('vpn.ip_addresses') ?? [];
+        $values = config('vpn.ip_addresses') ?? ['*'];
 
         if (is_string($values)) {
             $values = Str::of($values)


### PR DESCRIPTION
If the config isn't published, this value is null, so every IP address is blocked.