### PR TITLE
Allow all IP addresses when not configured

### DIFF
--- a/src/Middleware/RequireVpn.php
+++ b/src/Middleware/RequireVpn.php
@@ -56,8 +56,12 @@ class RequireVpn
      */
     public function allowedIps(): array
     {
-        /** @var array|array<int, string>|string $values */
-        $values = config('vpn.ip_addresses') ?? [];
+        /** @var array|array<int, string>|string|null $values */
+        $values = config('vpn.ip_addresses');
+
+        if ($values === null) {
+            return ['*'];
+        }
 
         if (is_string($values)) {
             $values = Str::of($values)

--- a/tests/Middleware/RequireVpnTest.php
+++ b/tests/Middleware/RequireVpnTest.php
@@ -27,8 +27,20 @@ class RequireVpnTest extends TestCase
     }
 
     #[Test]
+    public function it_can_allow_all_ips_when_not_configured(): void
+    {
+        $request = new Request();
+
+        $middleware = new RequireVpn();
+
+        $middleware->handle($request, fn () => $this->assertTrue(true));
+    }
+
+    #[Test]
     public function it_can_throw_an_exception_when_a_vpn_is_not_used(): void
     {
+        config()->set('vpn.ip_addresses', ['192.168.1.1']);
+
         $this->expectException(HttpException::class);
 
         $request = new Request();
@@ -78,7 +90,7 @@ class RequireVpnTest extends TestCase
         $middleware = new RequireVpn();
 
         config()->set('vpn.ip_addresses');
-        $this->assertSame([], $middleware->allowedIps());
+        $this->assertSame(['*'], $middleware->allowedIps());
 
         config()->set('vpn.ip_addresses', '');
         $this->assertSame([], $middleware->allowedIps());


### PR DESCRIPTION
If this package is installed, and the config isn't published, all requests were being blocked.

This changes the behavior to how it should work, where, if the config is not published, the middleware is effectively disabled, and all requests are allowed.