### PR TITLE
Add conditional Redis cluster support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ Support package for Solar Investments projects.
     - [Remove Trailing Slash](#remove-trailing-slash)
     - [Require VPN](#require-vpn)
     - [Set Fastly Surrogate Key](#set-fastly-surrogate-key)
+- [Service Providers](#service-providers)
+    - [RedisServiceProvider](#redisserviceprovider)
 - [URLs](#urls)
 - [Testing Traits](#testing-traits)
 ---
@@ -140,6 +142,27 @@ return [
     // ...
 
 ];
+```
+
+## Service Providers
+
+### RedisServiceProvider
+
+This provider modifies the `database.redis` configuration at runtime to enable Redis clustering automatically in production only **when running on Helio-managed projects**.
+
+Cluster mode is enabled only when **all** the following are true:
+
+- `APP_ENV` is `production`
+- `GCP_PROJECT_ID` is **not set** or equals `helio-platform`
+- `.env.production.encrypted` exists
+- `.github/workflows/helio.yml` exists
+
+If these conditions are met, Redis stores such as `default` and `cache` are moved into the `clusters` key to [enable Redis cluster support in Laravel](https://laravel.com/docs/12.x/redis#clusters).
+
+To force cluster mode in any environment:
+
+```dotenv
+FORCE_REDIS_CLUSTER=true
 ```
 
 ## URLs

--- a/src/Providers/RedisServiceProvider.php
+++ b/src/Providers/RedisServiceProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Providers;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Env;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use function is_array;
+
+class RedisServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        tap($this->app['config'], function (Repository $config): void {
+            /** @var array<string, mixed> $redis */
+            $redis = $config->get('database.redis', []);
+
+            if (Arr::has($redis, 'clusters')) {
+                return;
+            }
+
+            if (! $this->shouldEnableClusters()) {
+                return;
+            }
+
+            $clusters = $this->extractClusters($redis);
+
+            if ($clusters->isEmpty()) {
+                return;
+            }
+
+            $config->set('database.redis', [
+                'client' => Arr::get($redis, 'client'),
+                'options' => Arr::get($redis, 'options'),
+                'clusters' => $clusters->toArray(),
+            ]);
+        });
+    }
+
+    public function extractClusters(array $config): Collection
+    {
+        return collect($config)
+            ->except('client', 'options')
+            ->filter(fn (mixed $value): bool => is_array($value))
+            ->filter(fn (array $array): bool => Arr::has($array, 'url') || Arr::has($array, [
+                'host',
+                'port',
+            ]))
+            ->map(fn (array $server): array => [$server]);
+    }
+
+    public function shouldEnableClusters(): bool
+    {
+        if (Env::get('FORCE_REDIS_CLUSTER', false)) {
+            return true;
+        }
+
+        if (! $this->app->isProduction()) {
+            return false;
+        }
+
+        if (Env::get('GCP_PROJECT_ID', 'helio-platform') !== 'helio-platform') {
+            return false;
+        }
+
+        $hasProductionEnv = File::exists(base_path('.env.production.encrypted'));
+        $hasHelioWorkflow = File::exists(base_path('.github/workflows/helio.yml'));
+
+        return $hasProductionEnv && $hasHelioWorkflow;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,6 +12,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->register(Providers\MacroServiceProvider::class);
         $this->app->register(Providers\MiddlewareServiceProvider::class);
+        $this->app->register(Providers\RedisServiceProvider::class);
         $this->app->register(Providers\UrlServiceProvider::class);
     }
 }

--- a/tests/Middleware/EnableSecurePaginationLinksTest.php
+++ b/tests/Middleware/EnableSecurePaginationLinksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SolarInvestments\Tests\Middleware;
 
 use Illuminate\Http\Request;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
 use SolarInvestments\Middleware\EnableSecurePaginationLinks;
 use SolarInvestments\Tests\TestCase;
@@ -24,10 +25,9 @@ class EnableSecurePaginationLinksTest extends TestCase
     }
 
     #[Test]
+    #[DefineEnvironment('local')]
     public function it_cannot_handle_requests_when_running_locally(): void
     {
-        $this->app['env'] = 'local';
-
         $request = new Request();
 
         $middleware = new EnableSecurePaginationLinks();

--- a/tests/Middleware/RequireVpnTest.php
+++ b/tests/Middleware/RequireVpnTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SolarInvestments\Tests\Middleware;
 
 use Illuminate\Http\Request;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
 use SolarInvestments\Middleware\RequireVpn;
 use SolarInvestments\Tests\TestCase;
@@ -51,10 +52,9 @@ class RequireVpnTest extends TestCase
     }
 
     #[Test]
+    #[DefineEnvironment('local')]
     public function it_cannot_handle_requests_when_running_locally(): void
     {
-        $this->app['env'] = 'local';
-
         $request = new Request();
 
         $middleware = new RequireVpn();

--- a/tests/Providers/RedisServiceProviderTest.php
+++ b/tests/Providers/RedisServiceProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Tests\Providers;
+
+use Illuminate\Support\Facades\File;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+use SolarInvestments\Providers\RedisServiceProvider;
+use SolarInvestments\Tests\TestCase;
+
+class RedisServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function it_can_extract_clusters(): void
+    {
+        $clusters = (new RedisServiceProvider($this->app))->extractClusters(
+            config: config('database.redis')
+        );
+
+        $this->assertArrayHasKey('default', $clusters);
+        $this->assertArrayHasKey('cache', $clusters);
+
+        $this->assertSame([
+            [
+                'url' => null,
+                'host' => '127.0.0.1',
+                'username' => null,
+                'password' => null,
+                'port' => '6379',
+                'database' => '0',
+            ],
+        ], $clusters->get('default'));
+    }
+
+    #[Test]
+    #[DefineEnvironment('production')]
+    #[DefineEnvironment('usesDefaultProjectId')]
+    public function it_can_enable_clusters_when_all_conditions_are_met(): void
+    {
+        File::shouldReceive('exists')
+            ->with(base_path('.env.production.encrypted'))
+            ->andReturnTrue();
+
+        File::shouldReceive('exists')
+            ->with(base_path('.github/workflows/helio.yml'))
+            ->andReturnTrue();
+
+        $provider = new RedisServiceProvider($this->app);
+
+        $this->assertTrue($provider->shouldEnableClusters());
+    }
+
+    #[Test]
+    #[DefineEnvironment('local')]
+    #[DefineEnvironment('usesDefaultProjectId')]
+    public function it_can_disable_clusters_if_environment_is_not_production(): void
+    {
+        $provider = new RedisServiceProvider($this->app);
+
+        $this->assertFalse($provider->shouldEnableClusters());
+    }
+
+    #[Test]
+    #[DefineEnvironment('production')]
+    #[DefineEnvironment('usesNonDefaultProjectId')]
+    public function it_can_disable_clusters_if_not_default_project(): void
+    {
+        $provider = new RedisServiceProvider($this->app);
+
+        $this->assertFalse($provider->shouldEnableClusters());
+    }
+
+    #[Test]
+    #[DefineEnvironment('local')]
+    #[DefineEnvironment('forcesRedisCluster')]
+    public function it_can_allow_manual_override_with_force_flag(): void
+    {
+        $provider = new RedisServiceProvider($this->app);
+
+        $this->assertTrue($provider->shouldEnableClusters());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,4 +43,9 @@ abstract class TestCase extends BaseTestCase
             $config->set('session.driver', 'array');
         });
     }
+
+    protected function local(Application $app): void
+    {
+        $app['env'] = 'local';
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,4 +48,9 @@ abstract class TestCase extends BaseTestCase
     {
         $app['env'] = 'local';
     }
+
+    protected function production(Application $app): void
+    {
+        $app['env'] = 'production';
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,15 @@ abstract class TestCase extends BaseTestCase
         Http::preventStrayRequests();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Cleanup...
+        putenv('FORCE_REDIS_CLUSTER');
+        putenv('GCP_PROJECT_ID');
+    }
+
     /**
      * @param  Application  $app
      */
@@ -52,5 +61,20 @@ abstract class TestCase extends BaseTestCase
     protected function production(Application $app): void
     {
         $app['env'] = 'production';
+    }
+
+    protected function forcesRedisCluster(): void
+    {
+        putenv('FORCE_REDIS_CLUSTER=true');
+    }
+
+    protected function usesDefaultProjectId(): void
+    {
+        putenv('GCP_PROJECT_ID=helio-platform');
+    }
+
+    protected function usesNonDefaultProjectId(): void
+    {
+        putenv('GCP_PROJECT_ID=not-helio-platform');
     }
 }


### PR DESCRIPTION
Adds automatic Redis cluster configuration in production environments when deployed via Helio. The logic is encapsulated in `RedisServiceProvider` and auto-registered by the package's root provider.

Clustering is enabled only when:

- `APP_ENV` is `production`
- `GCP_PROJECT_ID` is **not set** or equals `helio-platform`
- `.env.production.encrypted` exists
- `.github/workflows/helio.yml` exists

You can override detection with:

```dotenv
FORCE_REDIS_CLUSTER=true
```

When enabled, the `database.redis` config is transformed so Redis stores are moved under the `clusters` key.