### PR TITLE
Honor all forwarded IPs when checking VPN access

### DIFF
--- a/src/Middleware/RequireVpn.php
+++ b/src/Middleware/RequireVpn.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use function in_array;
 use function is_string;
 
 class RequireVpn
@@ -30,25 +29,27 @@ class RequireVpn
 
     public function isUsingVpn(Request $request): bool
     {
-        if (($ips = $this->allowedIps()) === []) {
+        if (($allowedIps = $this->allowedIps()) === []) {
             return false;
         }
 
-        if ($ips === ['*']) {
+        if ($allowedIps === ['*']) {
             return true;
         }
 
-        if (($clientIp = $request->ip()) === null) {
-            return false;
-        }
-
-        foreach ($ips as $ip) {
-            if (Str::contains($ip, '/') && $this->ipWithinCidr($ip, $clientIp)) {
-                return true;
+        foreach ($request->ips() as $clientIp) {
+            foreach ($allowedIps as $allowedIp) {
+                if (Str::contains($allowedIp, '/')) {
+                    if ($this->ipWithinCidr($allowedIp, $clientIp)) {
+                        return true;
+                    }
+                } elseif ($clientIp === $allowedIp) {
+                    return true;
+                }
             }
         }
 
-        return in_array($clientIp, $ips, strict: true);
+        return false;
     }
 
     /**

--- a/tests/Middleware/RequireVpnTest.php
+++ b/tests/Middleware/RequireVpnTest.php
@@ -133,4 +133,38 @@ class RequireVpnTest extends TestCase
 
         $this->assertFalse($middleware->ipWithinCidr("$network/32", $ip));
     }
+
+    #[Test]
+    public function it_can_allow_when_any_forwarded_ip_matches_cidr(): void
+    {
+        $request = new Request();
+
+        $request->server->set('REMOTE_ADDR', '203.0.113.1');
+        $request->headers->set('X-Forwarded-For', '203.0.113.1, 10.1.2.3');
+
+        Request::setTrustedProxies(
+            proxies: ['203.0.113.1'],
+            trustedHeaderSet: Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PROTO |
+            Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT
+        );
+
+        $middleware = new RequireVpn();
+
+        config()->set('vpn.ip_addresses', ['10.0.0.0/8']);
+        $this->assertTrue($middleware->isUsingVpn($request));
+    }
+
+    #[Test]
+    public function it_cannot_allow_when_no_forwarded_ips_match(): void
+    {
+        $request = new Request();
+
+        $request->server->set('REMOTE_ADDR', '198.51.100.1');
+        $request->headers->set('X-Forwarded-For', '198.51.100.1, 203.0.113.2');
+
+        $middleware = new RequireVpn();
+
+        config()->set('vpn.ip_addresses', ['10.0.0.0/8']);
+        $this->assertFalse($middleware->isUsingVpn($request));
+    }
 }


### PR DESCRIPTION
Since `Request::ip()` may not return [the actual client IP](https://github.com/fideloper/TrustedProxy/issues/115#issuecomment-469459016) when behind a load balancer, this update modifies the middleware to check all IPs, ensuring accurate VPN enforcement when forwarded headers are present.

