### PR TITLE
Add service for environment-specific bootstrapping with Helio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,12 @@ return [
 
 This provider conditionally bootstraps Helio-specific configuration.
 
+It listens for Laravel's internal bootstrap events and applies environment-aware configuration such as:
+
+#### Logging
+
+Replaces the default log channel with a `stderr` Monolog driver using `GoogleCloudLoggingFormatter` and dynamic log levels (`debug` in non-production, `warning` in production).
+
 ### RedisServiceProvider
 
 This provider modifies the `database.redis` configuration at runtime to enable Redis clustering automatically in production only **when running on Helio-managed projects**.

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,10 @@ It listens for Laravel's internal bootstrap events and applies environment-aware
 
 Replaces the default log channel with a `stderr` Monolog driver using `GoogleCloudLoggingFormatter` and dynamic log levels (`debug` in non-production, `warning` in production).
 
+#### Statamic
+
+If Statamic is installed, it injects environment-aware `git` commit commands for Statamic's content publishing pipeline. This includes metadata like the current environment, project, and git user/email.
+
 ### RedisServiceProvider
 
 This provider modifies the `database.redis` configuration at runtime to enable Redis clustering automatically in production only **when running on Helio-managed projects**.

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Support package for Solar Investments projects.
     - [Require VPN](#require-vpn)
     - [Set Fastly Surrogate Key](#set-fastly-surrogate-key)
 - [Service Providers](#service-providers)
+    - [HelioServiceProvider](#helioserviceprovider)
     - [RedisServiceProvider](#redisserviceprovider)
 - [URLs](#urls)
 - [Testing Traits](#testing-traits)
@@ -145,6 +146,10 @@ return [
 ```
 
 ## Service Providers
+
+### HelioServiceProvider
+
+This provider conditionally bootstraps Helio-specific configuration.
 
 ### RedisServiceProvider
 

--- a/src/Providers/HelioServiceProvider.php
+++ b/src/Providers/HelioServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Providers;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+use SolarInvestments\Services\Helio;
+
+class HelioServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if (! File::isDirectory(base_path('.helio'))) {
+            return;
+        }
+
+        $this->app['events']->listen(
+            'bootstrapping: *',
+            fn (string $bootstrapper) => Helio::bootstrapperBootstrapping(
+                $this->app,
+                bootstrapper: Str::after($bootstrapper, 'bootstrapping: ')
+            )
+        );
+
+        $this->app['events']->listen(
+            'bootstrapped: *',
+            fn (string $bootstrapper) => Helio::bootstrapperBootstrapped(
+                $this->app,
+                Str::after($bootstrapper, 'bootstrapped: ')
+            )
+        );
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,6 +10,7 @@ class ServiceProvider extends BaseServiceProvider
 {
     public function register(): void
     {
+        $this->app->register(Providers\HelioServiceProvider::class);
         $this->app->register(Providers\MacroServiceProvider::class);
         $this->app->register(Providers\MiddlewareServiceProvider::class);
         $this->app->register(Providers\RedisServiceProvider::class);

--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -7,6 +7,9 @@ namespace SolarInvestments\Services;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Monolog\Formatter\GoogleCloudLoggingFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
 
 class Helio
 {
@@ -22,9 +25,32 @@ class Helio
                 //
             },
             HandleExceptions::class => static function () use ($app): void {
-                //
+                static::configureLogging($app);
             },
             default => static fn () => true,
         })();
+    }
+
+    public static function configureLogging(Application $app): void
+    {
+        if ($app->isLocal()) {
+            return;
+        }
+
+        $app['config']->set('logging.default', 'stderr');
+
+        $app['config']->set('logging.channels.stderr', [
+            'driver' => 'monolog',
+            'level' => $app->isProduction() ? 'warning' : 'debug',
+            'handler' => StreamHandler::class,
+            'handler_with' => [
+                'stream' => 'php://stderr',
+            ],
+            'formatter' => GoogleCloudLoggingFormatter::class,
+            'formatter_with' => [
+                'includeStacktraces' => true,
+            ],
+            'processors' => [PsrLogMessageProcessor::class],
+        ]);
     }
 }

--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Services;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+
+class Helio
+{
+    public static function bootstrapperBootstrapping(Application $app, string $bootstrapper): void
+    {
+        //
+    }
+
+    public static function bootstrapperBootstrapped(Application $app, string $bootstrapper): void
+    {
+        (match ($bootstrapper) {
+            LoadConfiguration::class => static function () use ($app): void {
+                //
+            },
+            HandleExceptions::class => static function () use ($app): void {
+                //
+            },
+            default => static fn () => true,
+        })();
+    }
+}

--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -7,6 +7,7 @@ namespace SolarInvestments\Services;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Support\Env;
 use Monolog\Formatter\GoogleCloudLoggingFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -22,7 +23,7 @@ class Helio
     {
         (match ($bootstrapper) {
             LoadConfiguration::class => static function () use ($app): void {
-                //
+                static::configureStatamic($app);
             },
             HandleExceptions::class => static function () use ($app): void {
                 static::configureLogging($app);
@@ -51,6 +52,28 @@ class Helio
                 'includeStacktraces' => true,
             ],
             'processors' => [PsrLogMessageProcessor::class],
+        ]);
+    }
+
+    public static function configureStatamic(Application $app): void
+    {
+        $name = Env::get('STATAMIC_GIT_USER_NAME', '{{ name }}');
+        $email = Env::get('STATAMIC_GIT_USER_EMAIL', '{{ email }}');
+        $project = Env::get('GCP_PROJECT_ID', 'helio-platform');
+
+        $app['config']->set('statamic.git.commands', [
+            '{{ git }} add {{ paths }}',
+            collect([
+                '{{ git }}',
+                '-c user.name="'.$name.'"',
+                '-c user.email="'.$email.'"',
+                'commit',
+                '-m "[skip ci] {{ message }}"',
+                '-m "environment='.$app['env'].'"',
+                '-m "project='.$project.'"',
+                '-m "user.email={{ email }}"',
+                '-m "user.name={{ name }}"',
+            ])->implode(' '),
         ]);
     }
 }

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SolarInvestments\Tests\Providers;
 
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Monolog\Formatter\GoogleCloudLoggingFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -49,5 +50,23 @@ class HelioServiceProviderTest extends TestCase
         Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
 
         $this->assertSame('debug', config('logging.channels.stderr.level'));
+    }
+
+    #[Test]
+    public function it_can_configure_statamic(): void
+    {
+        Helio::bootstrapperBootstrapped($this->app, LoadConfiguration::class);
+
+        $commands = config('statamic.git.commands');
+
+        $this->assertIsArray($commands);
+        $this->assertCount(2, $commands);
+        $this->assertSame('{{ git }} add {{ paths }}', $commands[0]);
+        $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[1]);
+        $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[1]);
+        $this->assertStringContainsString('-m "environment=testing"', $commands[1]);
+        $this->assertStringContainsString('-m "project=helio-platform"', $commands[1]);
+        $this->assertStringContainsString('-m "user.email={{ email }}"', $commands[1]);
+        $this->assertStringContainsString('-m "user.name={{ name }}"', $commands[1]);
     }
 }

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Tests\Providers;
+
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Monolog\Formatter\GoogleCloudLoggingFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+use SolarInvestments\Services\Helio;
+use SolarInvestments\Tests\TestCase;
+
+class HelioServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function it_can_configure_logging(): void
+    {
+        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+
+        $this->assertSame('stderr', config('logging.default'));
+
+        $channel = config('logging.channels.stderr');
+
+        $this->assertIsArray($channel);
+        $this->assertSame('monolog', $channel['driver']);
+        $this->assertSame('php://stderr', $channel['handler_with']['stream']);
+        $this->assertSame(StreamHandler::class, $channel['handler']);
+        $this->assertSame(GoogleCloudLoggingFormatter::class, $channel['formatter']);
+        $this->assertTrue($channel['formatter_with']['includeStacktraces']);
+        $this->assertContains(PsrLogMessageProcessor::class, $channel['processors']);
+    }
+
+    #[Test]
+    #[DefineEnvironment('production')]
+    public function it_can_set_the_logging_level_to_warning_when_in_production(): void
+    {
+        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+
+        $this->assertSame('warning', config('logging.channels.stderr.level'));
+    }
+
+    #[Test]
+    #[DefineEnvironment('local')]
+    public function it_can_set_the_logging_level_to_debug_when_not_in_production(): void
+    {
+        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+
+        $this->assertSame('debug', config('logging.channels.stderr.level'));
+    }
+}


### PR DESCRIPTION
Adds the foundational `HelioServiceProvider` and `Helio` service class to support conditional environment-specific bootstrapping logic for Helio-managed applications.

- The service provider registers listeners for Laravel's `bootstrapping:*` and `bootstrapped:*` events to enable hook-based configuration
- Boot logic is only executed for applications managed by Helio

---

Current bootstrapped configuration includes:

#### Logging
Overrides the default logger to `stderr` using `GoogleCloudLoggingFormatter` and stack traces enabled for better GCP compatibility.

#### Statamic Git integration

Dynamically configures `statamic.git.commands` with environment-aware commit metadata (`user`, `email`, `project`, `env`).

---

This creates a flexible foundation for further Helio-aware configuration (e.g. queue, scheduler, observability) during application boot.