### PR TITLE
Allow health check routes to bypass VPN middleware

### DIFF
--- a/src/Middleware/RequireVpn.php
+++ b/src/Middleware/RequireVpn.php
@@ -22,6 +22,10 @@ class RequireVpn
             return $next($request);
         }
 
+        if ($request->routeIs('probes.*') || $request->is('up')) {
+            return $next($request);
+        }
+
         abort_unless($this->isUsingVpn($request), Response::HTTP_FORBIDDEN);
 
         return $next($request);

--- a/tests/Middleware/RequireVpnTest.php
+++ b/tests/Middleware/RequireVpnTest.php
@@ -24,7 +24,13 @@ class RequireVpnTest extends TestCase
 
         $middleware = new RequireVpn();
 
-        $middleware->handle($request, fn () => $this->assertTrue(true));
+        $called = false;
+
+        $middleware->handle($request, function () use (&$called): void {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
     }
 
     #[Test]
@@ -34,7 +40,13 @@ class RequireVpnTest extends TestCase
 
         $middleware = new RequireVpn();
 
-        $middleware->handle($request, fn () => $this->assertTrue(true));
+        $called = false;
+
+        $middleware->handle($request, function () use (&$called): void {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
     }
 
     #[Test]
@@ -59,7 +71,13 @@ class RequireVpnTest extends TestCase
 
         $middleware = new RequireVpn();
 
-        $middleware->handle($request, fn () => $this->assertTrue(true));
+        $called = false;
+
+        $middleware->handle($request, function () use (&$called): void {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
     }
 
     #[Test]

--- a/tests/Middleware/RequireVpnTest.php
+++ b/tests/Middleware/RequireVpnTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SolarInvestments\Tests\Middleware;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
 use SolarInvestments\Middleware\RequireVpn;
@@ -184,5 +185,49 @@ class RequireVpnTest extends TestCase
 
         config()->set('vpn.ip_addresses', ['10.0.0.0/8']);
         $this->assertFalse($middleware->isUsingVpn($request));
+    }
+
+    #[Test]
+    public function it_can_allow_requests_to_health_path(): void
+    {
+        $middleware = new RequireVpn();
+
+        $request = Request::create('/up');
+
+        $request->server->set('REMOTE_ADDR', '198.51.100.1');
+
+        config()->set('vpn.ip_addresses', ['10.0.0.0/8']);
+
+        $called = false;
+
+        $middleware->handle($request, function () use (&$called): void {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
+    #[Test]
+    public function it_can_allow_requests_to_named_probes_route(): void
+    {
+        $middleware = new RequireVpn();
+
+        $request = new Request();
+
+        $request->server->set('REMOTE_ADDR', '198.51.100.1');
+
+        $request->setRouteResolver(fn () => (new Route('GET', '/probes/test', [
+            'as' => 'probes.test',
+        ])));
+
+        config()->set('vpn.ip_addresses', ['10.0.0.0/8']);
+
+        $called = false;
+
+        $middleware->handle($request, function () use (&$called): void {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
     }
 }


### PR DESCRIPTION
This update modifies the `RequireVpn` middleware to allow requests to health check endpoints to bypass VPN enforcement:

- Requests to the `/up` path
- Requests to routes named `probes.*`

These changes ensure that Kubernetes liveness and readiness probes are not blocked when VPN restrictions are enabled.