### PR TITLE
Fix Helio config not being registered

### DIFF
--- a/src/Providers/HelioServiceProvider.php
+++ b/src/Providers/HelioServiceProvider.php
@@ -6,7 +6,6 @@ namespace SolarInvestments\Providers;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use SolarInvestments\Services\Helio;
 
 class HelioServiceProvider extends ServiceProvider
@@ -17,20 +16,9 @@ class HelioServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app['events']->listen(
-            'bootstrapping: *',
-            fn (string $bootstrapper) => Helio::bootstrapperBootstrapping(
-                $this->app,
-                bootstrapper: Str::after($bootstrapper, 'bootstrapping: ')
-            )
-        );
-
-        $this->app['events']->listen(
-            'bootstrapped: *',
-            fn (string $bootstrapper) => Helio::bootstrapperBootstrapped(
-                $this->app,
-                Str::after($bootstrapper, 'bootstrapped: ')
-            )
-        );
+        if (! $this->app->configurationIsCached()) {
+            Helio::configureLogging($this->app);
+            Helio::configureStatamic($this->app);
+        }
     }
 }

--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -6,8 +6,6 @@ namespace SolarInvestments\Services;
 
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Foundation\Bootstrap\HandleExceptions;
-use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Support\Env;
 use Monolog\Formatter\GoogleCloudLoggingFormatter;
 use Monolog\Handler\StreamHandler;
@@ -15,24 +13,6 @@ use Monolog\Processor\PsrLogMessageProcessor;
 
 class Helio
 {
-    public static function bootstrapperBootstrapping(Application $app, string $bootstrapper): void
-    {
-        //
-    }
-
-    public static function bootstrapperBootstrapped(Application $app, string $bootstrapper): void
-    {
-        (match ($bootstrapper) {
-            LoadConfiguration::class => static function () use ($app): void {
-                static::configureStatamic($app);
-            },
-            HandleExceptions::class => static function () use ($app): void {
-                static::configureLogging($app);
-            },
-            default => static fn () => true,
-        })();
-    }
-
     public static function configureLogging(Application $app): void
     {
         if ($app->isLocal()) {

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace SolarInvestments\Tests\Providers;
 
-use Illuminate\Foundation\Bootstrap\HandleExceptions;
-use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Monolog\Formatter\GoogleCloudLoggingFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -19,7 +17,7 @@ class HelioServiceProviderTest extends TestCase
     #[Test]
     public function it_can_configure_logging(): void
     {
-        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+        Helio::configureLogging($this->app);
 
         $this->assertSame('stderr', config('logging.default'));
 
@@ -38,7 +36,7 @@ class HelioServiceProviderTest extends TestCase
     #[DefineEnvironment('production')]
     public function it_can_set_the_logging_level_to_warning_when_in_production(): void
     {
-        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+        Helio::configureLogging($this->app);
 
         $this->assertSame('warning', config('logging.channels.stderr.level'));
     }
@@ -47,7 +45,7 @@ class HelioServiceProviderTest extends TestCase
     #[DefineEnvironment('local')]
     public function it_can_set_the_logging_level_to_debug_when_not_in_production(): void
     {
-        Helio::bootstrapperBootstrapped($this->app, HandleExceptions::class);
+        Helio::configureLogging($this->app);
 
         $this->assertSame('debug', config('logging.channels.stderr.level'));
     }
@@ -55,7 +53,7 @@ class HelioServiceProviderTest extends TestCase
     #[Test]
     public function it_can_configure_statamic(): void
     {
-        Helio::bootstrapperBootstrapped($this->app, LoadConfiguration::class);
+        Helio::configureStatamic($this->app);
 
         $commands = config('statamic.git.commands');
 


### PR DESCRIPTION
Fixes an issue where Helio's configuration overrides were not being triggered because they were previously registered too late in the application lifecycle. Specifically, the `bootstrapping:*` event listeners in the service provider were ineffective since Laravel fires those events before package service providers are registered.

- Moved `Helio::configureLogging()` and `Helio::configureStatamic()` into the service provider's `register()` method to ensure they run early enough

Helio now correctly configures during app boot without requiring manual intervention or modification of Laravel core files.