### PR TITLE
Make probe routes always accessible

### DIFF
--- a/src/Middleware/AllowHealthCheckRequestsDuringMaintenance.php
+++ b/src/Middleware/AllowHealthCheckRequestsDuringMaintenance.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolarInvestments\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+
+class AllowHealthCheckRequestsDuringMaintenance extends PreventRequestsDuringMaintenance
+{
+    protected $except = [
+        '/probes/liveness',
+        '/probes/liveness/backend',
+        '/probes/liveness/scheduler',
+        '/probes/liveness/worker',
+        '/probes/readiness',
+    ];
+}

--- a/src/Providers/HealthCheckServiceProvider.php
+++ b/src/Providers/HealthCheckServiceProvider.php
@@ -6,10 +6,12 @@ namespace SolarInvestments\Providers;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use SolarInvestments\Console\Commands\HeartbeatCommand;
 use SolarInvestments\Http\Controllers\ProbeController;
 use SolarInvestments\Jobs\HeartbeatJob;
+use SolarInvestments\Middleware\AllowHealthCheckRequestsDuringMaintenance;
 
 class HealthCheckServiceProvider extends ServiceProvider
 {
@@ -21,10 +23,15 @@ class HealthCheckServiceProvider extends ServiceProvider
         $this->app->make(ProbeController::class);
     }
 
+    /**
+     * @throws BindingResolutionException
+     */
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
         $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
+
+        $this->configureMiddleware();
 
         if (! $this->app->runningInConsole() || $this->app->runningUnitTests()) {
             return;
@@ -37,5 +44,15 @@ class HealthCheckServiceProvider extends ServiceProvider
             $schedule->job(new HeartbeatJob())->everyMinute();
             $schedule->command('healthcheck:heartbeat')->everyMinute();
         });
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    protected function configureMiddleware(): void
+    {
+        $this->app->make(Kernel::class)->prependMiddleware(
+            AllowHealthCheckRequestsDuringMaintenance::class
+        );
     }
 }


### PR DESCRIPTION
Allows `/probe/*` routes to always be accessible, even when the application is in maintenance mode.