### PR TITLE
Prepend `git pull` to command sequence

### DIFF
--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -49,6 +49,7 @@ class Helio
         $project = Env::get('GCP_PROJECT_ID', 'helio-platform');
 
         $config->set('statamic.git.commands', [
+            '{{ git }} pull',
             '{{ git }} add {{ paths }}',
             collect([
                 '{{ git }}',

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -58,13 +58,14 @@ class HelioServiceProviderTest extends TestCase
         $commands = config('statamic.git.commands');
 
         $this->assertIsArray($commands);
-        $this->assertCount(2, $commands);
-        $this->assertSame('{{ git }} add {{ paths }}', $commands[0]);
-        $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[1]);
-        $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[1]);
-        $this->assertStringContainsString('-m "environment=testing"', $commands[1]);
-        $this->assertStringContainsString('-m "project=helio-platform"', $commands[1]);
-        $this->assertStringContainsString('-m "user.email={{ email }}"', $commands[1]);
-        $this->assertStringContainsString('-m "user.name={{ name }}"', $commands[1]);
+        $this->assertCount(3, $commands);
+        $this->assertSame('{{ git }} pull', $commands[0]);
+        $this->assertSame('{{ git }} add {{ paths }}', $commands[1]);
+        $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[2]);
+        $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[2]);
+        $this->assertStringContainsString('-m "environment=testing"', $commands[2]);
+        $this->assertStringContainsString('-m "project=helio-platform"', $commands[2]);
+        $this->assertStringContainsString('-m "user.email={{ email }}"', $commands[2]);
+        $this->assertStringContainsString('-m "user.name={{ name }}"', $commands[2]);
     }
 }


### PR DESCRIPTION
This change prepends `git pull` to the `statamic.git.commands` array to ensure the working tree is up to date before committing and pushing.

By combining this with `pull.rebase` and `rebase.autoStash` [config changes](https://github.com/Solar-Investments/helio/commit/5f5157e0b56647dd16983c590a61a1b67d53ed45), we can avoid push failures.