### PR TITLE
Manually set options to avoid push conflicts

### DIFF
--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -49,7 +49,7 @@ class Helio
         $project = Env::get('GCP_PROJECT_ID', 'helio-platform');
 
         $config->set('statamic.git.commands', [
-            '{{ git }} pull',
+            '{{ git }} pull --autostash --rebase',
             '{{ git }} add {{ paths }}',
             collect([
                 '{{ git }}',

--- a/src/Services/Helio.php
+++ b/src/Services/Helio.php
@@ -49,6 +49,7 @@ class Helio
         $project = Env::get('GCP_PROJECT_ID', 'helio-platform');
 
         $config->set('statamic.git.commands', [
+            '{{ git }} pull',
             '{{ git }} add {{ paths }}',
             collect([
                 '{{ git }}',

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -59,7 +59,7 @@ class HelioServiceProviderTest extends TestCase
 
         $this->assertIsArray($commands);
         $this->assertCount(3, $commands);
-        $this->assertSame('{{ git }} pull', $commands[0]);
+        $this->assertSame('{{ git }} pull --autostash --rebase', $commands[0]);
         $this->assertSame('{{ git }} add {{ paths }}', $commands[1]);
         $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[2]);
         $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[2]);

--- a/tests/Providers/HelioServiceProviderTest.php
+++ b/tests/Providers/HelioServiceProviderTest.php
@@ -58,13 +58,14 @@ class HelioServiceProviderTest extends TestCase
         $commands = config('statamic.git.commands');
 
         $this->assertIsArray($commands);
-        $this->assertCount(2, $commands);
-        $this->assertSame('{{ git }} add {{ paths }}', $commands[0]);
-        $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[1]);
-        $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[1]);
-        $this->assertStringContainsString('-m "environment=testing"', $commands[1]);
-        $this->assertStringContainsString('-m "project=helio-platform"', $commands[1]);
-        $this->assertStringContainsString('-m "user.email={{ email }}"', $commands[1]);
-        $this->assertStringContainsString('-m "user.name={{ name }}"', $commands[1]);
+        $this->assertCount(3, $commands);
+        $this->assertSame('{{ git }} pull', $commands[0]);
+        $this->assertSame('{{ git }} add {{ paths }}', $commands[1]);
+        $this->assertStringContainsString('-c user.name="{{ name }}"', $commands[2]);
+        $this->assertStringContainsString('-c user.email="{{ email }}"', $commands[2]);
+        $this->assertStringContainsString('-m "environment=testing"', $commands[2]);
+        $this->assertStringContainsString('-m "project=helio-platform"', $commands[2]);
+        $this->assertStringContainsString('-m "user.email={{ email }}"', $commands[2]);
+        $this->assertStringContainsString('-m "user.name={{ name }}"', $commands[2]);
     }
 }


### PR DESCRIPTION
Although we set `pull.rebase` and `rebase.autoStash` in the global Git config, the environment used by Statamic's Git process does not read this due to `$HOME` being set to `/var/www`.

To ensure consistent behavior, we now explicitly pass `--rebase` and `--autostash` to the git pull command before committing and pushing content changes.

This prevents push failures caused by remote commits being ahead of the local branch, which would otherwise require manual intervention.